### PR TITLE
lower shot timeout for single shot weapons if there is no ammo left

### DIFF
--- a/Templates/Weapons/MiniGunRL.lua
+++ b/Templates/Weapons/MiniGunRL.lua
@@ -220,7 +220,7 @@ function MiniGunRL:Fire() -- rocket
         self.FireSFX(self.ObjOwner._Entity)
     else
         self.OutOfAmmoFX(self.ObjOwner._Entity,1)
-        self.ShotTimeOut = s.FireTimeout
+        self.ShotTimeOut = 4
     end
 end
 --============================================================================

--- a/Templates/Weapons/Shotgun.lua
+++ b/Templates/Weapons/Shotgun.lua
@@ -167,7 +167,7 @@ function Shotgun:Fire()
         self.FireSFX(self.ObjOwner._Entity)                 
     else
         self.OutOfAmmoFX(self.ObjOwner._Entity,1)
-        self.ShotTimeOut = s.FireTimeout
+        self.ShotTimeOut = 4
     end
 end
 --============================================================================
@@ -224,7 +224,7 @@ function Shotgun:AltFire()
         self.AltFireSFX(self.ObjOwner._Entity)                
     else
         self.OutOfAmmoFX(self.ObjOwner._Entity,2)
-        self.ShotTimeOut = s.AltFireTimeout
+        self.ShotTimeOut = 4
     end
 end
 --============================================================================

--- a/Templates/Weapons/StakeGunGL.lua
+++ b/Templates/Weapons/StakeGunGL.lua
@@ -115,7 +115,7 @@ function StakeGunGL:Fire(prevstate) -- Stake
         return obj
     else
         self.OutOfAmmoFX(self.ObjOwner._Entity,1)
-        self.ShotTimeOut = s.AltFireTimeout
+        self.ShotTimeOut = 4
     end
 end
 --============================================================================
@@ -180,7 +180,7 @@ function StakeGunGL:AltFire() -- grenade
         PlayLogicSound("FIRE",x,y,z,26,52,player)
     else
         self.OutOfAmmoFX(self.ObjOwner._Entity,2)
-        self.ShotTimeOut = s.AltFireTimeout
+        self.ShotTimeOut = 4
     end
 end
 --============================================================================


### PR DESCRIPTION
with NoAmmoSwitch = false, the shot delay from the last weapon with no ammo left can bleed into the next weapon selection. not removing it outright prevents the click noise from being played twice