### PR TITLE
Remove redundant TakeFX call

### DIFF
--- a/HUD/Console2.lua
+++ b/HUD/Console2.lua
@@ -182,18 +182,7 @@ function Console:Cmd_BREAKMATCH()
 end
 --=======================================================================
 function Console:Cmd_FORCERESPAWN()
-    for i,o in Game.PlayerStats do
-        if o.Spectator == 0 then
-            local player = Game:FindPlayerByClientID(o.ClientID)
-            player._timeToRespawn = 0
-            player:FreeBlockedObjects()
-            ENTITY.Release(player._Entity)
-            if player._Entity then
-                EntityToObject[player._Entity] = nil
-                player._Entity = nil
-            end
-        end
-    end
+    Game:ForceRespawn()
 end
 --=======================================================================
 function Console:Cmd_FORCESPECTATOR(clientid)    

--- a/Main/GameMPUtils.lua
+++ b/Main/GameMPUtils.lua
@@ -334,12 +334,12 @@ function Game:SetPCFWeapons(state)
 		Cfg.PCFWeapons = state
 		Game:Server2ClientCommand(0, state and "enablepcfweaponsall" or "disenablepcfweaponsall")
 		if MPCfg.GameMode == "People Can Fly" and MPCfg.PCFWeapons ~= state then -- Menu TakeFX sound fix
-			for i,o in Game.Players do
-				if not o._died then
-					if state then Game:GivePCFWeapons(o._Entity) end -- known bug: Painkiller weapon is not allocated when changing PCFWeapons in middle of a match (the state resets after death)
-					CPlayer.WeaponChangeConfirmation(o.ClientID, o._Entity, 4)
-				end
-			end
+			--for i,o in Game.Players do
+			--	if not o._died then
+			--		if state then Game:GivePCFWeapons(o._Entity) end -- known bug: Painkiller weapon is not allocated when changing PCFWeapons in middle of a match (the state resets after death)
+			--		CPlayer.WeaponChangeConfirmation(o.ClientID, o._Entity, 4)
+			--	end
+			--end
 			Console:Cmd_FORCERESPAWN() -- Respawn fixes the Painkiller weapon bug
 		end
 	end

--- a/Main/GameMPUtils.lua
+++ b/Main/GameMPUtils.lua
@@ -334,6 +334,7 @@ function Game:SetPCFWeapons(state)
 		Cfg.PCFWeapons = state
 		Game:Server2ClientCommand(0, state and "enablepcfweaponsall" or "disenablepcfweaponsall")
 		if MPCfg.GameMode == "People Can Fly" and MPCfg.PCFWeapons ~= state then -- Menu TakeFX sound fix
+			-- This logic no longer needs after introduction of ForceRespawn
 			--for i,o in Game.Players do
 			--	if not o._died then
 			--		if state then Game:GivePCFWeapons(o._Entity) end -- known bug: Painkiller weapon is not allocated when changing PCFWeapons in middle of a match (the state resets after death)

--- a/Main/GameMPUtils.lua
+++ b/Main/GameMPUtils.lua
@@ -334,7 +334,7 @@ function Game:SetPCFWeapons(state)
 		Cfg.PCFWeapons = state
 		Game:Server2ClientCommand(0, state and "enablepcfweaponsall" or "disenablepcfweaponsall")
 		if MPCfg.GameMode == "People Can Fly" and MPCfg.PCFWeapons ~= state then -- Menu TakeFX sound fix
-			-- This logic no longer needs after introduction of ForceRespawn
+			-- This logic is no longer needed after the introduction of ForceRespawn
 			--for i,o in Game.Players do
 			--	if not o._died then
 			--		if state then Game:GivePCFWeapons(o._Entity) end -- known bug: Painkiller weapon is not allocated when changing PCFWeapons in middle of a match (the state resets after death)

--- a/Main/GameMPUtils.lua
+++ b/Main/GameMPUtils.lua
@@ -341,7 +341,7 @@ function Game:SetPCFWeapons(state)
 			--		CPlayer.WeaponChangeConfirmation(o.ClientID, o._Entity, 4)
 			--	end
 			--end
-			Game:ForceRespawn() -- Respawn fixes the Painkiller weapon bug
+			Game:ForceRespawn() -- Respawn fixes the weapon bugs
 		end
 	end
 	if MPCfg.PCFWeapons ~= state then

--- a/Main/GameMPUtils.lua
+++ b/Main/GameMPUtils.lua
@@ -340,7 +340,7 @@ function Game:SetPCFWeapons(state)
 			--		CPlayer.WeaponChangeConfirmation(o.ClientID, o._Entity, 4)
 			--	end
 			--end
-			Console:Cmd_FORCERESPAWN() -- Respawn fixes the Painkiller weapon bug
+			Game:ForceRespawn() -- Respawn fixes the Painkiller weapon bug
 		end
 	end
 	if MPCfg.PCFWeapons ~= state then
@@ -439,7 +439,22 @@ function Game:RespawnAllPlayers()
     		if(ps.Spectator==0)then
 			Game:PlayerRespawnRequest(ps.ClientID)
 		end
-	end   
+	end
+end
+--=======================================================================
+function Game:ForceRespawn()
+	for i,o in Game.PlayerStats do
+		if o.Spectator == 0 then
+			local player = Game:FindPlayerByClientID(o.ClientID)
+			player._timeToRespawn = 0
+			player:FreeBlockedObjects()
+			ENTITY.Release(player._Entity)
+			if player._Entity then
+				EntityToObject[player._Entity] = nil
+				player._Entity = nil
+			end
+		end
+	end
 end
 --=======================================================================
 function Game:ResetAllSpectators()


### PR DESCRIPTION
This additional call causes unexpected TakeFX sounds in the menu. It's noisy and no longer needed after the introduction of ForceRespawn.